### PR TITLE
Stop requiring constant dependabot PRs

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -7,10 +7,10 @@ jobs:
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6
 
       - name: Cache dialyzer plts
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5
         with:
           path: priv/plts
           key: ${{runner.os}}-${{hashFiles('**/.tool-versions')}}-plts


### PR DESCRIPTION
We're fine just pulling in the latest until a major version change